### PR TITLE
allow times without microseconds

### DIFF
--- a/python_apps/api_clients/api_clients/utils.py
+++ b/python_apps/api_clients/api_clients/utils.py
@@ -198,5 +198,8 @@ def fromisoformat(time_string):
     only added in Python 3.7. Until LibreTime drops Python 3.6 support, this
     wrapper uses the old way of doing it.
     """
-    datetime_obj = datetime.datetime.strptime(time_string, "%H:%M:%S.%f")
+    try:
+        datetime_obj = datetime.datetime.strptime(time_string, "%H:%M:%S.%f")
+    except ValueError:
+        datetime_obj = datetime.datetime.strptime(time_string, "%H:%M:%S")
     return datetime_obj.time()

--- a/python_apps/api_clients/tests/utils_test.py
+++ b/python_apps/api_clients/tests/utils_test.py
@@ -92,6 +92,7 @@ class TestGetProtocol(unittest.TestCase):
         time = {
             "00:00:00.500000": datetime.time(microsecond=500000),
             "00:04:30.092540": datetime.time(minute=4, second=30, microsecond=92540),
+            "00:04:30": datetime.time(minute=4, second=30),
         }
         for time_string, expected in time.items():
             result = utils.fromisoformat(time_string)


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/airtime_playout-1.0-py3.6.egg/pypo/pypofetch.py", line 440, in manual_schedule_fetch
    self.schedule_data = self.api_client.get_schedule()
  File "/usr/local/lib/python3.6/dist-packages/api_clients-2.0.0-py3.6.egg/api_clients/version2.py", line 76, in get_schedule
    cue_in = time_in_seconds(fromisoformat(item['cue_in']))
  File "/usr/local/lib/python3.6/dist-packages/api_clients-2.0.0-py3.6.egg/api_clients/utils.py", line 174, in fromisoformat
    datetime_obj = datetime.datetime.strptime(time_string, "%H:%M:%S.%f")
  File "/usr/lib/python3.6/_strptime.py", line 565, in _strptime_datetime
    tt, fraction = _strptime(data_string, format)
  File "/usr/lib/python3.6/_strptime.py", line 362, in _strptime
    (data_string, format))
ValueError: time data '00:00:00' does not match format '%H:%M:%S.%f'
